### PR TITLE
Fix concurrency errors

### DIFF
--- a/src/pgqueue/core.clj
+++ b/src/pgqueue/core.clj
@@ -200,7 +200,7 @@
         locks (jdbc/query db
                 ["select classid, objid 
                   from pg_locks where classid = ?" table-oid])]
-    (swap! queue-locks {})
+    (reset! queue-locks {})
     (doseq [lock locks]
       (jdbc/query db
         ["select pg_advisory_unlock(?,?)"


### PR DESCRIPTION
I'm not sure if these are all the fixes needed, but this patch eliminates a lot of the issues I was having. The main problems were:

* `swap!` was used in a way that was not thread safe.
* The recursive SQL query did not correctly reference the working table, as in Que.
* There was no mechanism to lock the database connection while taking.

I have a feeling that this could be simplified further, but would require breaking changes, so I might write another library.